### PR TITLE
"php-http/discovery": "^1.7"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "magento/magento-composer-installer": "*",
         "mailgun/mailgun-php": "2.6.0",
         "php-http/guzzle6-adapter": "^1.0",
-        "php-http/discovery": "1.3.0"
+        "php-http/discovery": "^1.7"
         
     },
     "autoload": {


### PR DESCRIPTION
"php-http/discovery": "^1.7" for Magneto 2.3.5